### PR TITLE
Fix package.json for apps that use Common/msal-node-wrapper

### DIFF
--- a/1-Authentication/1-sign-in/App/package.json
+++ b/1-Authentication/1-sign-in/App/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest --forceExit",
-    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install"
+    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install && npm run build"
   },
   "author": "derisen",
   "license": "MIT",

--- a/1-Authentication/2-sign-in-b2c/App/package.json
+++ b/1-Authentication/2-sign-in-b2c/App/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest --forceExit",
-    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install"
+    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install && npm run build"
   },
   "author": "derisen",
   "license": "MIT",

--- a/2-Authorization/1-call-graph/App/package.json
+++ b/2-Authorization/1-call-graph/App/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest --forceExit",
-    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install"
+    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install && npm run build"
   },
   "author": "derisen",
   "license": "MIT",

--- a/4-AccessControl/1-app-roles/App/package.json
+++ b/4-AccessControl/1-app-roles/App/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest --forceExit",
-    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install"
+    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install && npm run build"
   },
   "author": "derisen",
   "license": "MIT",

--- a/4-AccessControl/2-security-groups/App/package.json
+++ b/4-AccessControl/2-security-groups/App/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest --forceExit",
-    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install"
+    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install && npm run build"
   },
   "author": "derisen",
   "license": "MIT",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

Fixes the following issue I was having when running `npm start` in multiple of the sample apps:

```
> msal-node-tutorial-signin@1.0.0 start
> node server.js

Debugger listening on ws://127.0.0.1:55549/65f5719b-e016-4956-81b6-ba598dfd90fa
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
Waiting for the debugger to disconnect...
node:internal/modules/cjs/loader:444
      throw err;
      ^

Error: Cannot find module '/Users/tylervz/src/azure_active_directory_demos/ms-identity-javascript-nodejs-tutorial/ms-identity-javascript-nodejs-tutorial/1-Authentication/1-sign-in/App/node_modules/msal-node-wrapper/dist/index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:436:19)
    at Module._findPath (node:internal/modules/cjs/loader:678:18)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1061:27)
    at Module._load (node:internal/modules/cjs/loader:920:27)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)
    at Object.<anonymous> (/Users/tylervz/src/azure_active_directory_demos/ms-identity-javascript-nodejs-tutorial/ms-identity-javascript-nodejs-tutorial/1-Authentication/1-sign-in/App/app.js:9:32)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/tylervz/src/azure_active_directory_demos/ms-identity-javascript-nodejs-tutorial/ms-identity-javascript-nodejs-tutorial/1-Authentication/1-sign-in/App/node_modules/msal-node-wrapper/package.json',
  requestPath: 'msal-node-wrapper'
}

Node.js v18.16.0
```

## Does this introduce a breaking change

<!-- mark with an `x` -->

```console
    [ ] Yes
    [x] No
```

## Pull request type

What kind of change does this Pull Request introduce?

<!-- mark with an `x` -->

```console
    [x] Bugfix
    [ ] Feature
    [ ] Code style update (formatting, local variables)
    [ ] Documentation content changes
    [ ] Other... Please describe:
```

## How to test

* Get the code

```console
    git clone git@github.com:tylervz/ms-identity-javascript-nodejs-tutorial.git
    cd ms-identity-javascript-nodejs-tutorial
    git checkout fix-npm-install
    cd 1-Authentication\1-sign-in\App
    npm install
```

## What to check

ex: verify that the following are valid:

* `npm start` starts the express server should start and you can access the sample app in a browser at <http://localhost:4000>.


## Other Information
<!-- Add any other helpful information that may be needed here. -->
I'm using npm verison 9.5.1 , Node.js v18.16.0 , macOS Ventura 13.4.1