### PR TITLE
Fix: add `build` script to `postinstall` script

### DIFF
--- a/1-Authentication/1-sign-in/App/package.json
+++ b/1-Authentication/1-sign-in/App/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "jest --forceExit",
-    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install"
+    "postinstall": "cd ../../../Common/msal-node-wrapper && npm install && npm run build"
   },
   "author": "derisen",
   "license": "MIT",


### PR DESCRIPTION
# Pull Request

## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

This PR adds a `npm run build` script to `postinstall` script in `/1-Authentication/1-Sign-in/App/package.json`, to solve the following problem when running `npm start`

![image](https://github.com/Azure-Samples/ms-identity-javascript-nodejs-tutorial/assets/27288153/0e3b7768-0ef9-4542-a423-bbf5c3408534)

```shell
❯ npm start

> msal-node-tutorial-signin@1.0.0 start
> node server.js

node:internal/modules/cjs/loader:446
      throw err;
      ^

Error: Cannot find module 'C:\Users\Yulei_Chen\github\ms-identity-javascript-nodejs-tutorial\1-Authentication\1-sign-in\App\node_modules\msal-node-wrapper\dist\index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:438:19)
    at Module._findPath (node:internal/modules/cjs/loader:680:18)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1063:27)
    at Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:121:18)
    at Object.<anonymous> (C:\Users\Yulei_Chen\github\ms-identity-javascript-nodejs-tutorial\1-Authentication\1-sign-in\App\app.js:9:32)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32) {
  code: 'MODULE_NOT_FOUND',
  path: 'C:\\Users\\Yulei_Chen\\github\\ms-identity-javascript-nodejs-tutorial\\1-Authentication\\1-sign-in\\App\\node_modules\\msal-node-wrapper\\package.json',   
  requestPath: 'msal-node-wrapper'
}

Node.js v18.17.1
```

This bug is because it's the first time I run `npm start` in any chapter, the helper inside `/Common` hasn't been built before.
Actually, we need to add `npm run build` to every `postinstall` in case of the above bug, but this PR just adds for `/1-Authentication/1-sign-in/`.

## Does this introduce a breaking change

<!-- mark with an `x` -->

```console
    [ ] Yes
    [x] No
```

## Pull request type

What kind of change does this Pull Request introduce?

<!-- mark with an `x` -->

```console
    [x] Bugfix
    [ ] Feature
    [ ] Code style update (formatting, local variables)
    [ ] Documentation content changes
    [ ] Other... Please describe:
```

## How to test

* Get the code

```console
    git clone https://github.com/yuleicul/ms-identity-javascript-nodejs-tutorial.git
    cd ms-identity-javascript-nodejs-tutorial
    git checkout yulei-patch-1
    cd 1-Authentication/1-sign-in/App
    npm install
    npm start
```

## What to check

ex: verify that the following are valid:

* The server can be started successfully after running `npm start`

## Other Information
<!-- Add any other helpful information that may be needed here. -->

Related issue: [Please Fix the following issue I was having when running npm start in sample \4-AccessControl\2-security-groups · Issue #100 · Azure-Samples/ms-identity-javascript-nodejs-tutorial](https://github.com/Azure-Samples/ms-identity-javascript-nodejs-tutorial/issues/100)